### PR TITLE
Define  "RSpec.configure" method when running "rake db:test:prepare".

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 0.3.0
 ---
-Removed restriction on needing to use sidekiq-middleware with be_unique matcher [philostler#4]
+* Removed restriction on needing to use sidekiq-middleware with be_unique matcher [philostler#4]
+* Ensure RSpec.configure is defined on loading rspec/sidekiq/matchers [centaure]
 
 0.2.2
 ---

--- a/lib/rspec/sidekiq/matchers.rb
+++ b/lib/rspec/sidekiq/matchers.rb
@@ -1,3 +1,4 @@
+require "rspec/core"
 require "rspec/sidekiq/matchers/be_processed_in"
 require "rspec/sidekiq/matchers/be_retryable"
 require "rspec/sidekiq/matchers/have_enqueued_job"


### PR DESCRIPTION
Loading "rspec/core" defines "RSpec.configure" when running 
"rake db:test:prepare". Without loading "rspec/core", you get the 
error:
"undefined method `configure' for RSpec:Module"
 
