### PR TITLE
Fix matches? method for be_retryable matcher

### DIFF
--- a/lib/rspec/sidekiq/matchers/be_retryable.rb
+++ b/lib/rspec/sidekiq/matchers/be_retryable.rb
@@ -25,7 +25,7 @@ module RSpec
         end
 
         def matches? job
-          @klass = job.class
+          @klass = job
           @actual = @klass.get_sidekiq_options["retry"]
           @actual == @expected
         end


### PR DESCRIPTION
be_retryable matcher, `matches?` method is using `@klass = job.class` instead of `@klass = job`. 

This is causing error:

```
NoMethodError:
       undefined method `get_sidekiq_options' for Class:Class
```
