### PR TITLE
Allow to use rspec general matchers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Master
+---
+* Allow to use [general matchers](https://www.relishapp.com/rspec/rspec-mocks/v/2-14/docs/argument-matchers/general-matchers) in have_enqueued_job [johanneswuerbach#30]
+
 1.0.0
 ---
 * Add delay extension matchers [sosaucily#22]

--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -22,7 +22,7 @@ module RSpec
         def matches? klass
           @klass = klass
           @actual = klass.jobs.map { |job| job["args"] }
-          @actual.include? @expected
+          @actual.any? { |args| Array(@expected) == args }
         end
 
         def negative_failure_message

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe "Have Enqueued Job matcher" do
+  describe "expect syntax" do
+    before do
+      TestWorker.perform_async('5')
+    end
+    it "correctly matches" do
+      expect(TestWorker).to have_enqueued_job('5')
+    end
+
+    it "correctly matches using a general matcher" do
+      expect(TestWorker).to have_enqueued_job(an_instance_of(String))
+    end
+  end
+end


### PR DESCRIPTION
This allows to match using [rspec general matchers](https://www.relishapp.com/rspec/rspec-mocks/v/2-14/docs/argument-matchers/general-matchers).
