### PR TITLE
Add helper for testing retries exhausted block.

### DIFF
--- a/lib/rspec-sidekiq.rb
+++ b/lib/rspec-sidekiq.rb
@@ -1,6 +1,7 @@
 require "sidekiq/testing"
 
 require "rspec/sidekiq/configuration"
+require "rspec/sidekiq/helpers"
 require "rspec/sidekiq/matchers"
 require "rspec/sidekiq/sidekiq"
 require "rspec/sidekiq/batch"

--- a/lib/rspec/sidekiq/helpers.rb
+++ b/lib/rspec/sidekiq/helpers.rb
@@ -1,0 +1,2 @@
+require "rspec/core"
+require "rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block"

--- a/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
+++ b/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
@@ -1,0 +1,14 @@
+module Sidekiq
+  module Worker
+
+    module ClassMethods
+      def within_sidekiq_retries_exhausted_block(&block)
+        block.call
+
+        self.sidekiq_retries_exhausted_block.call
+      end
+    end
+
+  end
+end
+

--- a/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
+++ b/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'Retries Exhausted block' do
+
+  class FooClass < TestWorkerAlternative
+    sidekiq_retries_exhausted do |msg|
+      bar('hello')
+    end
+
+    def self.bar(input)
+    end
+  end
+
+  it 'executes whatever is within the block' do
+    FooClass.within_sidekiq_retries_exhausted_block { FooClass.should_receive(:bar).with('hello') }
+  end
+
+end


### PR DESCRIPTION
The block `sidekiq_retries_exhausted` currently lacks an easy way to kick
it off and test it in RSpec. Add a helper that will kick off the block
in order to test what happens within it.
