### PR TITLE
Prepare for RSpec 3.x

### DIFF
--- a/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
+++ b/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
@@ -12,7 +12,7 @@ describe 'Retries Exhausted block' do
   end
 
   it 'executes whatever is within the block' do
-    FooClass.within_sidekiq_retries_exhausted_block { FooClass.should_receive(:bar).with('hello') }
+    FooClass.within_sidekiq_retries_exhausted_block { expect(FooClass).to receive(:bar).with('hello') }
   end
 
 end

--- a/spec/rspec/sidekiq/matchers/be_processed_in_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_processed_in_spec.rb
@@ -54,13 +54,13 @@ describe RSpec::Sidekiq::Matchers::BeProcessedIn do
     context "when condition matches" do
       context "when expected is a symbol" do
         it "returns true" do
-          expect(symbol_subject.matches? symbol_worker).to be_true
+          expect(symbol_subject.matches? symbol_worker).to be true
         end
       end
 
       context "when expected is a string" do
         it "returns true" do
-          expect(string_subject.matches? string_worker).to be_true
+          expect(string_subject.matches? string_worker).to be true
         end
       end
     end
@@ -68,13 +68,13 @@ describe RSpec::Sidekiq::Matchers::BeProcessedIn do
     context "when condition does not match" do
       context "when expected is a symbol" do
         it "returns false" do
-          expect(symbol_subject.matches? create_worker queue: :another_queue).to be_false
+          expect(symbol_subject.matches? create_worker queue: :another_queue).to be false
         end
       end
 
       context "when expected is a string" do
         it "returns false" do
-          expect(string_subject.matches? create_worker queue: "another_queue").to be_false
+          expect(string_subject.matches? create_worker queue: "another_queue").to be false
         end
       end
     end

--- a/spec/rspec/sidekiq/matchers/be_retryable_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_retryable_spec.rb
@@ -69,19 +69,19 @@ describe RSpec::Sidekiq::Matchers::BeRetryable do
     context "when condition matches" do
       context "when expected is a number" do
         it "returns true" do
-          expect(specific_subject.matches? specific_worker).to be_true
+          expect(specific_subject.matches? specific_worker).to be true
         end
       end
 
       context "when expected is true" do
         it "returns true" do
-          expect(default_subject.matches? default_worker).to be_true
+          expect(default_subject.matches? default_worker).to be true
         end
       end
 
       context "when expected is false" do
         it "returns true" do
-          expect(negative_subject.matches? negative_worker).to be_true
+          expect(negative_subject.matches? negative_worker).to be true
         end
       end
     end
@@ -89,19 +89,19 @@ describe RSpec::Sidekiq::Matchers::BeRetryable do
     context "when condition does not match" do
       context "when expected is a number" do
         it "returns false" do
-          expect(specific_subject.matches? default_worker).to be_false
+          expect(specific_subject.matches? default_worker).to be false
         end
       end
 
       context "when expected is true" do
         it "returns false" do
-          expect(default_subject.matches? negative_worker).to be_false
+          expect(default_subject.matches? negative_worker).to be false
         end
       end
 
       context "when expected is false" do
         it "returns false" do
-          expect(negative_subject.matches? specific_worker).to be_false
+          expect(negative_subject.matches? specific_worker).to be false
         end
       end
     end

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -31,13 +31,13 @@ describe RSpec::Sidekiq::Matchers::BeUnique do
   describe "#matches?" do
     context "when condition matches" do
       it "returns true" do
-        expect(subject.matches? worker).to be_true
+        expect(subject.matches? worker).to be true
       end
     end
 
     context "when condition does not match" do
       it "returns false" do
-        expect(subject.matches? create_worker unique: false).to be_false
+        expect(subject.matches? create_worker unique: false).to be false
       end
     end
   end


### PR DESCRIPTION
1. Eliminated be_true and be_false matchers.
2. Changed remaining should to expect.
