### PR TITLE
Travis - Ruby 2.1.0, fix Rubinius build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
   - jruby-19mode
   - jruby-head
-  - rbx-head
+  - rbx
 script: "bundle exec rspec spec"
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx-head
+    - rvm: rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source "https://rubygems.org"
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end
+
 gemspec


### PR DESCRIPTION
1. Added Ruby 2.1.0 to Travis
2. Got Rubinius specs running (if not passing) again
