### PR TITLE
Fix Rubinius build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 platforms :rbx do
   gem "rubysl", "~> 2.0"
+  gem "psych"
   gem "rubinius-developer_tools"
 end
 


### PR DESCRIPTION
Explicitly added psych to Gemfile for Rubinius, so YAML serialization in delay does not fail.

Note that as of time of writing, 2.1.0 builds are failing on Travis.  This is a Travis issue, and doesn't relate to problems in the code.  Travis needs to update their images to use Bundler 1.5.1 to address this issue - https://github.com/bundler/bundler/issues/2780 .  According to Twitter Travis is aware and an update is underway.
