### PR TITLE
Fixe gem build error ERROR: (Gem::InvalidSpecificationException)

### DIFF
--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "coveralls", "~> 0.7.0"
   s.add_development_dependency "fuubar", ">= 1.1.0"
-  s.add_development_dependency "rspec", ">= 2.0.0"
-  s.add_development_dependency "sidekiq", ">= 2.4.0"
 
   s.files = Dir[".gitattributes"] +
             Dir[".gitignore"] +


### PR DESCRIPTION
- Removed duplicate dependency on rspec (>= 2.0.0, development), (>= 2.0.0)
- Removed duplicate dependency on sidekiq (>= 2.4.0, development), (>= 2.4.0)
