### PR TITLE
Make sure sidekiq is required

### DIFF
--- a/lib/rspec-sidekiq.rb
+++ b/lib/rspec-sidekiq.rb
@@ -1,3 +1,4 @@
+require "sidekiq"
 require "sidekiq/testing"
 
 require "rspec/sidekiq/batch"


### PR DESCRIPTION
On test environment the following exception occurs
`alias_method': undefined method`raw_push' for class `Sidekiq::Client' (NameError)
## Step to reproduce
- Add rspec-sidekiq to Gemfile test group
- Install the gem
- Run rails console in test environment
## Related issue

https://github.com/philostler/rspec-sidekiq/issues/12
