### PR TITLE
Fix README example matcher usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ describe AwesomeJob do
   it { should be_unique }
 
   it "enqueues another awesome job" do
-    subject.perform
+    subject.perform_async("Awesome", true)
 
     expect(AnotherAwesomeJob).to have_enqueued_job("Awesome", true)
   end


### PR DESCRIPTION
`perform_async` is the thing that backgrounds the job, and we need to pass in arguments to be consistent here.
