### PR TITLE
attempt at fixing 'undefined method `configure' for RSpec:Module'

### DIFF
--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -1,3 +1,5 @@
+require "rspec/core"
+
 if defined? Sidekiq::Batch
   module RSpec
     module Sidekiq


### PR DESCRIPTION
simply adding require 'rspec/core' in the batch.rb file fixes error:

```
undefined method `configure' for RSpec:Module
```

when running `RAILS_ENV=test rake db:drop`
