### PR TITLE
Pass message hash to retries_exhausted block

### DIFF
--- a/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
+++ b/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
@@ -1,10 +1,18 @@
 module Sidekiq
   module Worker
     module ClassMethods
-      def within_sidekiq_retries_exhausted_block &block
+      def within_sidekiq_retries_exhausted_block user_msg = {}, &block
         block.call
+        self.sidekiq_retries_exhausted_block.call default_retries_exhausted_args.merge(user_msg)
+      end
 
-        self.sidekiq_retries_exhausted_block.call
+      def default_retries_exhausted_args
+        {
+          'queue' => get_sidekiq_options[:worker],
+          'class' => self.name,
+          'args' => [],
+          'error_message' => 'An error occured'
+        }
       end
     end
   end

--- a/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
+++ b/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
@@ -5,14 +5,25 @@ describe 'Retries Exhausted block' do
   class FooClass < TestWorkerAlternative
     sidekiq_retries_exhausted do |msg|
       bar('hello')
+      foo(msg)
     end
 
     def self.bar(input)
+    end
+
+    def self.foo(msg)
     end
   end
 
   it 'executes whatever is within the block' do
     FooClass.within_sidekiq_retries_exhausted_block { expect(FooClass).to receive(:bar).with('hello') }
+  end
+
+  it 'passes arguments to the block' do
+    args = {'args' => ['a', 'b']}
+    FooClass.within_sidekiq_retries_exhausted_block(args) do
+      expect(FooClass).to receive(:foo).with(FooClass.default_retries_exhausted_args.merge(args))
+    end
   end
 
 end


### PR DESCRIPTION
Allows you to pass data to the `sidekiq_retries_exhausted` block, with a default set of data that is always passed in order to conform more closely to how Sidekiq works. Without this, testing the retry mechanism of some workers is either impossible or incredibly difficult.
