### PR TITLE
Get specs to green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - ruby-head

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -31,9 +31,9 @@ describe RSpec::Sidekiq::Matchers::BeUnique do
         end
       end
 
-      describe '#negative_failure_message' do
+      describe '#failure_message_when_negated' do
         it 'returns message' do
-          expect(subject.negative_failure_message).to eq "expected #{@worker} to not be unique in the queue"
+          expect(subject.failure_message_when_negated).to eq "expected #{@worker} to not be unique in the queue"
         end
       end
     end
@@ -57,7 +57,7 @@ describe RSpec::Sidekiq::Matchers::BeUnique do
 
   describe '#failure_message_when_negated' do
     it 'returns message' do
-      expect(subject.failure_message_when_negated).to eq "expected #{worker} to not be unique in the queue"
+      expect(subject.failure_message_when_negated).to eq "expected #{@worker} to not be unique in the queue"
     end
   end
 end


### PR DESCRIPTION
1. Remove Ruby 1.9.3 which is not supported with Sidekiq 3.x.
2. Fix failing spec on `negative_failure_message` by updating to the RSpec 3.x method name `failure_message_when_negated`.
3. Added a missing '@' which was causing a spec to fail.
