### PR TITLE
Change stubbing batches to explicit opt-in rather than opt-out

### DIFF
--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -61,7 +61,7 @@ if defined? Sidekiq::Batch
 
   RSpec.configure do |config|
     config.before(:each) do |example|
-      next if example.metadata[:stub_batches] == false
+      next unless example.metadata[:stub_batches]
 
       if mocked_with_mocha?
         Sidekiq::Batch.stubs(:new) { RSpec::Sidekiq::NullBatch.new }

--- a/spec/rspec/sidekiq/batch_spec.rb
+++ b/spec/rspec/sidekiq/batch_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Batch' do
 
   load File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/rspec/sidekiq/batch.rb'))
 
-  describe 'NullStatus' do
+  describe 'NullStatus', stub_batches: true do
     describe '#total' do
       it 'returns 0 when no jobs' do
         null_status = Sidekiq::Batch.new.status


### PR DESCRIPTION
When including rspec-sidekiq into a project with existing batch related specs, the NullBatch behavior caused a lot of headaches.  

In that situation, we found it much easier to change 'stub_batches' to be opt-in rather than opt-out. 
