### PR TITLE
Sidekiq Enterprise: until matcher

### DIFF
--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -27,7 +27,7 @@ module RSpec
               "but its interval was #{actual_interval} seconds"
             elsif !expiration_matches?
               "expected #{@klass} to be unique until #{@expected_expiration}, "\
-              "but its unique_until was #{actual_expiration}"
+              "but its unique_until was #{actual_expiration || 'not specified'}"
             else
               "expected #{@klass} to be unique in the queue"
             end

--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -25,6 +25,9 @@ module RSpec
             if !interval_matches? && @expected_interval
               "expected #{@klass} to be unique for #{@expected_interval} seconds, "\
               "but its interval was #{actual_interval} seconds"
+            elsif !expiration_matches?
+              "expected #{@klass} to be unique until #{@expected_expiration}, "\
+              "but its unique_until was #{actual_expiration}"
             else
               "expected #{@klass} to be unique in the queue"
             end
@@ -33,11 +36,16 @@ module RSpec
           def matches?(job)
             @klass = job.is_a?(Class) ? job : job.class
             @actual = @klass.get_sidekiq_options[unique_key]
-            !!(value_matches? && interval_matches?)
+            !!(value_matches? && interval_matches? && expiration_matches?)
           end
 
           def for(interval)
             @expected_interval = interval
+            self
+          end
+
+          def until(expiration)
+            @expected_expiration = expiration
             self
           end
 
@@ -47,6 +55,10 @@ module RSpec
 
           def interval_matches?
             !interval_specified? || actual_interval == @expected_interval
+          end
+
+          def expiration_matches?
+            @expected_expiration.nil? || actual_expiration ==  @expected_expiration
           end
 
           def failure_message_when_negated
@@ -71,6 +83,10 @@ module RSpec
         class SidekiqEnterprise < Base
           def actual_interval
             @actual
+          end
+
+          def actual_expiration
+            @klass.get_sidekiq_options['unique_until']
           end
 
           def value_matches?

--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -71,6 +71,10 @@ module RSpec
             @klass.get_sidekiq_options['unique_job_expiration']
           end
 
+          def actual_expiration
+            fail 'until is not supported for SidekiqUniqueJobs'
+          end
+
           def value_matches?
             [true, :all].include?(@actual)
           end

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -75,12 +75,23 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
 
     it { should be_unique.for(interval).until(:success) }
 
-    context 'failure' do
+    context 'errors' do
       subject { expect(super()).to be_unique.for(interval).until(:started) }
 
-      it do
-        expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
-          'expected MuhWorker to be unique until started, but its unique_until was success'
+      context 'when there is a mismatch' do
+        it do
+          expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
+            'expected MuhWorker to be unique until started, but its unique_until was success'
+        end
+      end
+
+      context 'when not specified' do
+        let(:expiration) { nil }
+
+        it do
+          expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
+            'expected MuhWorker to be unique until started, but its unique_until was not specified'
+        end
       end
     end
   end


### PR DESCRIPTION
## Description
In Sidekiq Enterprise's [Unique Jobs](https://github.com/mperham/sidekiq/wiki/Ent-Unique-Jobs#unlock-policy) feature, you have the ability to specify an unlock policy.

This PR adds an `until` matcher so that you may specify an expectation against a worker for it like so:

```ruby
describe MuhWorker do
  it { should be_unique.until(:success) }
end
```

It also will `fail` that it is not supported if a user tries to use it with `SidekiqUniqueJobs`.