### PR TITLE
Add support for matching argument

### DIFF
--- a/lib/rspec/sidekiq/matchers/be_delayed.rb
+++ b/lib/rspec/sidekiq/matchers/be_delayed.rb
@@ -59,7 +59,8 @@ module RSpec
         def find_job(method, arguments, &block)
           job = (::Sidekiq::Extensions::DelayedClass.jobs + ::Sidekiq::Extensions::DelayedModel.jobs + ::Sidekiq::Extensions::DelayedMailer.jobs).find do |job|
             yaml = YAML.load(job['args'].first)
-            @expected_method_receiver == yaml[0] && @expected_method.name == yaml[1] && (@expected_arguments <=> yaml[2]) == 0
+            matcher = ::RSpec::Mocks::ArgumentListMatcher.new(*@expected_arguments)
+            @expected_method_receiver == yaml[0] && @expected_method.name == yaml[1] && matcher.args_match?(*yaml[2])
           end
 
           yield job if block && job

--- a/spec/rspec/sidekiq/matchers/be_delayed_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_delayed_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 RSpec.describe RSpec::Sidekiq::Matchers::BeDelayed do
   let(:delay_subject) { RSpec::Sidekiq::Matchers::BeDelayed.new }
   let(:delay_with_arguments_subject) { RSpec::Sidekiq::Matchers::BeDelayed.new Object }
+  let(:delay_with_matching_arguments_subject) { RSpec::Sidekiq::Matchers::BeDelayed.new Object, any_args }
   let(:delay_for_subject) { RSpec::Sidekiq::Matchers::BeDelayed.new.for 3600 }
   let(:delay_for_with_arguments_subject) { RSpec::Sidekiq::Matchers::BeDelayed.new(Object).for 3600 }
   let(:delay_until_subject) { RSpec::Sidekiq::Matchers::BeDelayed.new.until Time.now + 3600 }
@@ -123,6 +124,14 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeDelayed do
           Object.delay.is_a? Object
 
           expect(delay_with_arguments_subject.matches? Object.method :is_a?).to be true
+        end
+      end
+
+      context 'when expected is a delay with matching arguments' do
+        it 'returns true' do
+          Object.delay.is_a? Object
+
+          expect(delay_with_matching_arguments_subject.matches? Object.method :is_a?).to be true
         end
       end
 


### PR DESCRIPTION
(Please consider adding support for matching argument) To allow not only the exact argument but also its regular expressions or any non-nil arguments to pass.
Thanks for your support and help.

See also:
https://relishapp.com/rspec/rspec-mocks/v/3-1/docs/setting-constraints/matching-arguments

Examples:

```
# old
SlackApi.sidekiq_delay.post_to('message')

expect(SlackApi.method :post_to).to be_delayed('message') #=> OK
expect(SlackApi.method :post_to).to be_delayed #=> NG
expect(SlackApi.method :post_to).to be_delayed(/^message/) #=> NG
expect(SlackApi.method :post_to).to be_delayed(any_args) #=> NG


# new
SlackApi.sidekiq_delay.post_to('message')

expect(SlackApi.method :post_to).to be_delayed('message') #=> OK
expect(SlackApi.method :post_to).to be_delayed #=> NG
expect(SlackApi.method :post_to).to be_delayed(/^message/) #=> OK
expect(SlackApi.method :post_to).to be_delayed(any_args) #=> OK
```