### PR TITLE
Fix time comparing in have_enqueued_sidekiq_job

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -11,6 +11,8 @@ module RSpec
       end
 
       class JobOptionParser
+        DELTA = 1
+
         attr_reader :job
 
         def initialize(job)
@@ -26,12 +28,12 @@ module RSpec
 
         def at_evaluator(value)
           return false if job['at'].to_s.empty?
-          value.to_time.to_i == Time.at(job['at']).to_i
+          (value.to_time.to_f - Time.at(job['at']).to_f).abs < DELTA
         end
 
         def in_evaluator(value)
           return false if job['at'].to_s.empty?
-          (Time.now + value).to_i == Time.at(job['at']).to_i
+          ((Time.now + value).to_f - Time.at(job['at']).to_f).abs < DELTA
         end
       end
 


### PR DESCRIPTION
Following spec fails for me from time to time and this PR should fix it. 

```ruby
    subject.perform(args)
    expect(described_class).to have_enqueued_sidekiq_job(args).in(15.minutes)
```