### PR TITLE
remove deprecated method "have_enqueued_job"

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,6 @@ AwesomeJob.perform_async 'Awesome', true
 # test with...
 expect(AwesomeJob).to have_enqueued_sidekiq_job('Awesome', true)
 
-# Code written with older versions of the gem may use the deprecated
-# have_enqueued_job matcher.
-expect(AwesomeJob).to have_enqueued_job('Awesome', true)
 ```
 
 #### Testing scheduled jobs

--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -5,11 +5,6 @@ module RSpec
         HaveEnqueuedJob.new expected_arguments
       end
 
-      def have_enqueued_job(*expected_arguments)
-        warn "[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead."
-        have_enqueued_sidekiq_job(*expected_arguments)
-      end
-
       class JobOptionParser
         attr_reader :job
 

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -90,20 +90,6 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
     end
   end
 
-  describe '#have_enqueued_job' do
-    it 'returns instance' do
-      expect(have_enqueued_job).to be_a RSpec::Sidekiq::Matchers::HaveEnqueuedJob
-    end
-
-    it 'provides deprecation warning' do
-      expect { have_enqueued_job }.to output(/[DEPRECATION]/).to_stderr
-    end
-
-    it 'matches the same way have_enqueued_sidekiq_job does' do
-      expect(worker).to have_enqueued_job *worker_args
-    end
-  end
-
   describe '#description' do
     it 'returns description' do
       argument_subject.matches? worker


### PR DESCRIPTION
this deprecated method collide with the one from rspec https://relishapp.com/rspec/rspec-rails/docs/matchers/have-enqueued-job-matcher