### PR TITLE
Ignore argument check when expected_arguments empty

### DIFF
--- a/lib/rspec/sidekiq/matchers/be_delayed.rb
+++ b/lib/rspec/sidekiq/matchers/be_delayed.rb
@@ -59,7 +59,9 @@ module RSpec
         def find_job(method, arguments, &block)
           job = (::Sidekiq::Extensions::DelayedClass.jobs + ::Sidekiq::Extensions::DelayedModel.jobs + ::Sidekiq::Extensions::DelayedMailer.jobs).find do |job|
             yaml = YAML.load(job['args'].first)
-            @expected_method_receiver == yaml[0] && @expected_method.name == yaml[1] && (@expected_arguments <=> yaml[2]) == 0
+            @expected_method_receiver == yaml[0] &&
+              @expected_method.name == yaml[1] &&
+              (@expected_arguments.empty? || (@expected_arguments <=> yaml[2]) == 0)
           end
 
           yield job if block && job

--- a/spec/rspec/sidekiq/matchers/be_delayed_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_delayed_spec.rb
@@ -115,6 +115,10 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeDelayed do
           Object.delay.nil?
 
           expect(delay_subject.matches? Object.method :nil?).to be true
+
+          Object.delay.is_a? Object
+
+          expect(delay_subject.matches? Object.method :is_a?).to be true
         end
       end
 


### PR DESCRIPTION
This PR addresses https://github.com/philostler/rspec-sidekiq/issues/178. In this PR I tried to be as non-intrusive as possible, and doing the strict minimum to solve the issue. I have also added some tests for this.

Another option which is mentioned in the issue as well would be to use `ArgumentListMatcher` from `rspec-mocks`, which would give us a more powerful fuzzy matcher from `rspec`.

It's my first time contributing here so please do tell me if there are some things you would like to see done differently.