### PR TITLE
Correct evaluation for "in" option

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -18,7 +18,7 @@ module RSpec
         end
 
         def matches?(option, value)
-          raise ArgumentError, "Option `#{option}` is not defined." unless %w(in at).include?(option.to_s)
+          raise ArgumentError, "Option `#{option}` is not defined." unless %w[at].include?(option.to_s)
           send("#{option}_evaluator", value)
         end
 
@@ -26,12 +26,7 @@ module RSpec
 
         def at_evaluator(value)
           return false if job['at'].to_s.empty?
-          value.to_time.to_i == Time.at(job['at']).to_i
-        end
-
-        def in_evaluator(value)
-          return false if job['at'].to_s.empty?
-          (Time.now + value).to_i == Time.at(job['at']).to_i
+          value == Time.at(job['at']).to_i
         end
       end
 
@@ -149,12 +144,12 @@ module RSpec
         end
 
         def at(timestamp)
-          @expected_options['at'] = timestamp
+          @expected_options['at'] = timestamp.to_time.to_i
           self
         end
 
         def in(interval)
-          @expected_options['in'] = interval
+          @expected_options['at'] = (Time.now.to_f + interval.to_f).to_i
           self
         end
 

--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -75,7 +75,7 @@ module RSpec
       end
 
       class EnqueuedJobs
-        attr_reader :jobs, :actual_arguments, :actual_options
+        attr_reader :jobs
 
         def initialize(klass)
           @jobs = unwrap_jobs(klass.jobs)
@@ -93,7 +93,7 @@ module RSpec
           @actual_options ||= if jobs.is_a?(Hash)
             jobs.values
           else
-            jobs.flatten.map { |j| { 'at' => j['at'] } }
+            jobs.flatten.map { |j| {"at" => j["at"]} }
           end
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'rspec-sidekiq'
 
 require 'active_job'
 require 'action_mailer'
+require 'active_support/testing/time_helpers'
 
 require_relative 'support/init'
 
@@ -12,6 +13,7 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
 
   config.include RSpec::Sidekiq::Spec::Support::Factories
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # Add a setting to store our Sidekiq Version and share that around the specs
   config.add_setting :sidekiq_gte_7


### PR DESCRIPTION
First reported in #183 and solution from #182

Closes #183 

Additional freebies in this PR:

- Simplify the Job options matcher to just expect `at` since that's what will be on the Sidekiq Job. We move the parsing/handling of expected values for `at` versus `in` to the methods in `HaveEnqueuedJob`
- Also updates the description on mismatch to show an "at" expectation when using `in` as the actual Sidekiq job will show "at" on a mismatch (see below)

<img width="1169" alt="image" src="https://github.com/wspurgin/rspec-sidekiq/assets/3472781/90a37267-b731-48e1-8a57-66787d89b123">

The one downside of the failure message is that Sidekiq stores a `float` for the `at` option, and it might cause confusion when you first see the actual vs expected (your eye first goes to the missing `.0`. We purposefully coerce to integers to avoid fractional second drift when comparing.