### PR TITLE
Update failure message to list out actual jobs line-by-line

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -74,27 +74,37 @@ module RSpec
         end
       end
 
+      class EnqueuedJob
+        extend Forwardable
+        attr_reader :job
+        delegate :[] => :@job
+
+        def initialize(job)
+          @job = job
+        end
+
+        def jid
+          job["jid"]
+        end
+
+        def args
+          @actual_arguments ||= JobArguments.new(job).unwrapped_arguments
+        end
+
+        def context
+          @actual_options ||= job.except("args")
+        end
+      end
+
       class EnqueuedJobs
         attr_reader :jobs
 
         def initialize(klass)
-          @jobs = unwrap_jobs(klass.jobs)
+          @jobs = unwrap_jobs(klass.jobs).map { |job| EnqueuedJob.new(job) }
         end
 
         def includes?(arguments, options)
           !!jobs.find { |job| matches?(job, arguments, options) }
-        end
-
-        def actual_arguments
-          @actual_arguments ||= jobs.map { |job| JobArguments.new(job).unwrapped_arguments }
-        end
-
-        def actual_options
-          @actual_options ||= if jobs.is_a?(Hash)
-            jobs.values
-          else
-            jobs.flatten.map { |j| {"at" => j["at"]} }
-          end
         end
 
         private
@@ -124,21 +134,18 @@ module RSpec
       end
 
       class HaveEnqueuedJob
-        attr_reader :klass, :expected_arguments, :actual_arguments, :expected_options, :actual_options
+        attr_reader :klass, :expected_arguments, :expected_options, :actual_jobs
 
         def initialize(expected_arguments)
           @expected_arguments = expected_arguments
           @expected_options = {}
         end
 
-
         def matches?(klass)
           @klass = klass
 
           enqueued_jobs = EnqueuedJobs.new(klass)
-
-          @actual_arguments = enqueued_jobs.actual_arguments
-          @actual_options = enqueued_jobs.actual_options
+          @actual_jobs = enqueued_jobs.jobs
 
           enqueued_jobs.includes?(jsonified_expected_arguments, expected_options)
         end
@@ -165,13 +172,17 @@ module RSpec
           message << "    -#{expected_options}" if expected_options.any?
           message << "but have enqueued only jobs"
           if expected_arguments
-            message << "  with arguments:"
-            message << actual_arguments.sort_by { |a| a[0].to_s }.map { |a| "    -#{a}" }.join("\n")
-          end
+            job_messages = actual_jobs.map do |job|
+              base = "  -JID:#{job.jid} with arguments:"
+              base << "\n    -#{job.args}"
+              if expected_options.any?
+                base << "\n   with options: #{job.context.inspect}"
+              end
 
-          if expected_options.any?
-            message << "  with options:"
-            message << actual_options.sort_by { |a| a.to_a[0].to_s }.map { |o| "    -#{o}" }.join("\n")
+              base
+            end
+
+            message << job_messages.join("\n")
           end
 
           message.join("\n")

--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -164,8 +164,16 @@ module RSpec
           message << "  with options:" if expected_options.any?
           message << "    -#{expected_options}" if expected_options.any?
           message << "but have enqueued only jobs"
-          message.concat(["  with arguments:"], actual_arguments.sort_by { |a| a[0].to_s }.map { |a| "    -#{a}" }) if expected_arguments
-          message.concat(["  with options:"], actual_options.sort_by { |a| a.to_a[0].to_s }.map { |o| "    -#{o}" }) if expected_options.any?
+          if expected_arguments
+            message << "  with arguments:"
+            message << actual_arguments.sort_by { |a| a[0].to_s }.map { |a| "    -#{a}" }.join("\n")
+          end
+
+          if expected_options.any?
+            message << "  with options:"
+            message << actual_options.sort_by { |a| a.to_a[0].to_s }.map { |o| "    -#{o}" }.join("\n")
+          end
+
           message.join("\n")
         end
 


### PR DESCRIPTION
Should help in issues like #162 and #168 where the previous description made it harder to tell that the actual was an array of _jobs_ with arguments, not a single job with a single array arg.

New description would look like:
```ruby
SomeJob.perform_async "some_arg", "some_other_arg"

# Expectation accidentlly (or purposefully) expecting a single array arg
expect(SomeJob).to have_enqueued_sidekiq_job(["some_arg", "some_other_arg"])
#=> fails with message:
#
# expected to have an enqueued SomeJob job
#   with arguments:
#     -[["some_arg", "some_other_arg"]]
# but have enqueued only jobs
#   -JID:2b99eed860096f19c4b8df4d with arguments:
#     -["some_arg", "some_other_arg"]
# 
```

Closes #162
Closes #168

Also, it nests the "context" under each Job as well (formerly was "options" in the failure message - it's called the job hash "context" in Sidekiq, so I'm updating to use that terminology to be consistent).

The previous failure message only ever showed `"at"`, but I've elected to include the full job context without args in the output. I'm doing that to pave the way for a general `with_context` (not tied to the name) matcher to tests things like "retry" and "queue" too.

As an example, if we added the `in` matcher:
```ruby
SomeJob.perform_in 5.minutes, "some_arg", "some_other_arg"

# Expectation accidentlly (or purposefully) expecting a single array arg
expect(SomeJob).to have_enqueued_sidekiq_job(["some_arg", "some_other_arg"]).in(5.minutes)
#=> fails with message:
#
# expected to have an enqueued SomeJob job
#   with arguments:
#     -[["some_arg", "some_other_arg"]]
# but have enqueued only jobs
#   -JID:2b99eed860096f19c4b8df4d with arguments:
#     -["some_arg", "some_other_arg"]
#    with context:
#     -{"retry"=>true, "queue"=>"default", "class"=>"SomeJob", "at"=>1690385369.755574, "jid"=>"2b99eed860096f19c4b8df4d", "created_at"=>1690385069.755618}
# 
```