### PR TITLE
:bug: Fix be_delayed interval calculation

### DIFF
--- a/lib/rspec/sidekiq/matchers/be_delayed.rb
+++ b/lib/rspec/sidekiq/matchers/be_delayed.rb
@@ -38,7 +38,7 @@ module RSpec
           find_job @expected_method, @expected_arguments do |job|
             if @expected_interval
               created_enqueued_at = job['enqueued_at'] || job['created_at']
-              return job['at'].to_i == created_enqueued_at.to_i + @expected_interval
+              return job['at'].to_i == Time.at(created_enqueued_at.to_f + @expected_interval.to_f).to_i
             elsif @expected_time
               return job['at'].to_i == @expected_time.to_i
             else


### PR DESCRIPTION
`be_delayed` has it's own version of the the interval calculation. It was still doing basic `at.to_i + interval` which can cause false positives (as we saw [tw](https://github.com/wspurgin/rspec-sidekiq/actions/runs/5726557567/job/15517242650)i[ce](https://github.com/wspurgin/rspec-sidekiq/actions/runs/5726557567/attempts/1) on main in recent builds)