### PR TITLE
Remove have_enqueued_job and rename files/class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ prevent a name clash with rspec-rails' ActiveJob matcher.
 AwesomeJob.perform_async 'Awesome', true
 # test with...
 expect(AwesomeJob).to have_enqueued_sidekiq_job('Awesome', true)
-
-# Code written with older versions of the gem may use the deprecated
-# have_enqueued_job matcher.
-expect(AwesomeJob).to have_enqueued_job('Awesome', true)
 ```
 
 #### Testing scheduled jobs

--- a/lib/rspec/sidekiq/matchers.rb
+++ b/lib/rspec/sidekiq/matchers.rb
@@ -4,7 +4,7 @@ require 'rspec/sidekiq/matchers/be_expired_in'
 require 'rspec/sidekiq/matchers/be_processed_in'
 require 'rspec/sidekiq/matchers/be_retryable'
 require 'rspec/sidekiq/matchers/be_unique'
-require 'rspec/sidekiq/matchers/have_enqueued_job'
+require 'rspec/sidekiq/matchers/have_enqueued_sidekiq_job'
 require 'rspec/sidekiq/matchers/save_backtrace'
 
 RSpec.configure do |config|

--- a/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
@@ -2,12 +2,7 @@ module RSpec
   module Sidekiq
     module Matchers
       def have_enqueued_sidekiq_job(*expected_arguments)
-        HaveEnqueuedJob.new expected_arguments
-      end
-
-      def have_enqueued_job(*expected_arguments)
-        warn "[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead."
-        have_enqueued_sidekiq_job(*expected_arguments)
+        HaveEnqueuedSidekiqJob.new expected_arguments
       end
 
       class JobOptionParser
@@ -142,7 +137,7 @@ module RSpec
         end
       end
 
-      class HaveEnqueuedJob
+      class HaveEnqueuedSidekiqJob
         attr_reader :klass, :expected_arguments, :expected_options, :actual_jobs
 
         def initialize(expected_arguments)

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
+RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
   let(:tomorrow) { DateTime.now + 1 }
   let(:interval) { 3.minutes }
-  let(:argument_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new worker_args }
-  let(:matcher_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new [be_a(String), be_a(Integer), true, be_a(Hash)] }
+  let(:argument_subject) { described_class.new worker_args }
+  let(:matcher_subject) { described_class.new [be_a(String), be_a(Integer), true, be_a(Hash)] }
   let(:worker) { create_worker }
   let(:worker_args) { ['string', 1, true, { "key" => 'value', "bar" => "foo", "nested" => [{"hash" => true}] }] }
   let(:active_job) { create_active_job :mailers }
@@ -109,7 +109,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
   describe '#have_enqueued_sidekiq_job' do
     it 'returns instance' do
       worker.perform_async *worker_args
-      expect(have_enqueued_sidekiq_job).to be_a RSpec::Sidekiq::Matchers::HaveEnqueuedJob
+      expect(have_enqueued_sidekiq_job).to be_a described_class
     end
 
     it 'matches the same way have_enqueued_sidekiq_job does' do
@@ -142,7 +142,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
 
     context "when expected arguments is an array and multiple jobs enqueued" do
       let(:wrapped_args) { [worker_args] }
-      let(:argument_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new wrapped_args }
+      let(:argument_subject) { described_class.new wrapped_args }
 
       it "returns a message showing the wrapped array in expectations but each job on its own line" do
         jids = 2.times.map { worker.perform_async *worker_args }


### PR DESCRIPTION
`have_enqueued_job` has been deprecated for a long while now. This finally removes it entirely.