### PR TITLE
Use ArgumentListMatcher to ensure order and allow use of richer builtin Argument matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ AwesomeJob.perform_async 'Awesome', true
 expect(AwesomeJob).to have_enqueued_sidekiq_job('Awesome', true)
 ```
 
+You can use the built-in args matchers too:
+```ruby
+AwesomeJob.perform_async({"something" => "Awesome", "extra" => "stuff"})
+
+# using built-in matchers from rspec-mocks:
+expect(AwesomeJob).to have_enqueued_sidekiq_job(hash_including("something" => "Awesome"))
+expect(AwesomeJob).to have_enqueued_sidekiq_job(any_args)
+expect(AwesomeJob).to have_enqueued_sidekiq_job(hash_excluding("bad_stuff" => anything))
+```
+
 #### Testing scheduled jobs
 
 *Use chainable matchers `#at` and `#in`*

--- a/lib/rspec/sidekiq/matchers.rb
+++ b/lib/rspec/sidekiq/matchers.rb
@@ -1,4 +1,5 @@
 require 'rspec/core'
+require 'rspec/mocks/argument_list_matcher'
 require 'rspec/sidekiq/matchers/be_delayed'
 require 'rspec/sidekiq/matchers/be_expired_in'
 require 'rspec/sidekiq/matchers/be_processed_in'

--- a/lib/rspec/sidekiq/matchers/be_delayed.rb
+++ b/lib/rspec/sidekiq/matchers/be_delayed.rb
@@ -1,6 +1,8 @@
 module RSpec
   module Sidekiq
     module Matchers
+      include RSpec::Mocks::ArgumentMatchers
+
       def be_delayed(*expected_arguments)
         BeDelayed.new(*expected_arguments)
       end
@@ -71,7 +73,7 @@ module RSpec
 
             @expected_method_receiver == yaml[0] &&
               method.name == yaml[1] &&
-              (arguments.empty? || (arguments <=> yaml[2]) == 0)
+              (arguments.empty? || RSpec::Mocks::ArgumentListMatcher.new(*arguments).args_match?(*yaml[2]))
           end
 
           yield job if block && job

--- a/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
@@ -36,13 +36,17 @@ module RSpec
       end
 
       class JobArguments
+        include RSpec::Mocks::ArgumentMatchers
+
         def initialize(job)
           self.job = job
         end
         attr_accessor :job
 
         def matches?(expected_args)
-          RSpec::Matchers::BuiltIn::ContainExactly.new(expected_args).matches?(unwrapped_arguments)
+          matcher = RSpec::Mocks::ArgumentListMatcher.new(*expected_args)
+
+          matcher.args_match?(*unwrapped_arguments)
         end
 
         def unwrapped_arguments

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.add_dependency "rspec-core", "~> 3.0"
+  s.add_dependency "rspec-mocks", "~> 3.0"
   s.add_dependency "rspec-expectations", "~> 3.0"
   s.add_dependency "sidekiq", ">= 5", "< 8"
 

--- a/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
         expect(Sidekiq::Worker).to have_enqueued_sidekiq_job *worker_args
       end
 
+      context "when using bultin argument matchers" do
+        it "matches" do
+          worker.perform_async({"something" => "Awesome", "extra" => "stuff"})
+          expect(worker).to have_enqueued_sidekiq_job(hash_including("something" => "Awesome"))
+          expect(worker).to have_enqueued_sidekiq_job(any_args)
+          expect(worker).to have_enqueued_sidekiq_job(hash_excluding("bad_stuff" => anything))
+        end
+      end
+
       context 'perform_in' do
         let(:worker_args_in) { worker_args + ['in'] }
 

--- a/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
         expect(Sidekiq::Worker).to have_enqueued_sidekiq_job *worker_args
       end
 
-      context "when using bultin argument matchers" do
+      context "when using builtin argument matchers" do
         it "matches" do
           worker.perform_async({"something" => "Awesome", "extra" => "stuff"})
           expect(worker).to have_enqueued_sidekiq_job(hash_including("something" => "Awesome"))

--- a/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
@@ -230,6 +230,13 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
         it 'returns false' do
           expect(argument_subject.matches? worker).to be false
         end
+
+        context "and arguments are out of order" do
+          it "returns false" do
+            worker.perform_async(*worker_args.reverse)
+            expect(argument_subject.matches? worker).to be false
+          end
+        end
       end
 
       context 'when expected are matchers' do


### PR DESCRIPTION
Closes #144

Fixes a long standing bug where the order of args didn't matter.

Additionally, because we're now leveraging the ArgumentListMatcher we're actually able to supprot the ArgumentMatchers from `rspec-mocks`!