### PR TITLE
Load forwardable expressly

### DIFF
--- a/lib/rspec-sidekiq.rb
+++ b/lib/rspec-sidekiq.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 require 'sidekiq'
 require 'sidekiq/testing'
 


### PR DESCRIPTION
Sidekiq v6 does not load forwardable by `require 'sidekiq'; require 'sidekiq/testing'`
Therefore, depending on the library situation used, a `NameError` will be raised.

```
$ BUNDLE_GEMFILE=gemfiles/sidekiq6_5_rails7.gemfile bundle exec ruby -I lib -r rspec-sidekiq -e 1
/rspec-sidekiq/lib/rspec/sidekiq/matchers/base.rb:85:in `<class:EnqueuedJob>': uninitialized constant RSpec::Sidekiq::Matchers::EnqueuedJob::Forwardable (NameError)

        extend Forwardable
               ^^^^^^^^^^^
```

Explicitly loading forwardable solves the problem.
