### PR TITLE
Fix https://github.com/wspurgin/rspec-sidekiq/issues/207

### DIFF
--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -171,7 +171,7 @@ module RSpec
         end
 
         def with(*expected_arguments)
-          @expected_arguments = normalize_arguments(expected_arguments)
+          @expected_arguments = expected_arguments
           self
         end
 
@@ -237,17 +237,18 @@ module RSpec
           RSpec::Support::ObjectFormatter.format(thing)
         end
 
-        def normalize_arguments(args)
-          if args.is_a?(Array)
-            args.map{ |x| normalize_arguments(x) }
-          elsif args.is_a?(Hash)
-            args.each_with_object({}) do |(key, value), hash|
-              hash[key.to_s] = normalize_arguments(value)
+        def jsonified_expected_arguments
+          # We would just cast-to-parse-json, but we need to support
+          # RSpec matcher args like #kind_of
+          @jsonified_expected_arguments ||= begin
+            expected_arguments.map do |arg|
+              case arg.class
+              when Symbol then arg.to_s
+              when Hash then JSON.parse(arg.to_json)
+              else
+                arg
+              end
             end
-          elsif args.is_a?(Symbol)
-            args.to_s
-          else
-            args
           end
         end
       end

--- a/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
@@ -9,7 +9,7 @@ module RSpec
       class HaveEnqueuedSidekiqJob < Base
         def initialize(expected_arguments)
           super()
-          @expected_arguments = normalize_arguments(expected_arguments)
+          @expected_arguments = expected_arguments
         end
 
         def matches?(job_class)
@@ -17,7 +17,7 @@ module RSpec
 
           @actual_jobs = EnqueuedJobs.new(klass)
 
-          actual_jobs.includes?(expected_arguments, expected_options)
+          actual_jobs.includes?(jsonified_expected_arguments, expected_options)
         end
       end
     end

--- a/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::EnqueueSidekiqJob do
         it "returns true" do
           expect {
             worker.perform_async("foo", {"some_arg" => "etc"})
-          }.to enqueue_sidekiq_job.with(:foo, {some_arg: :etc})
+          }.to enqueue_sidekiq_job.with("foo", {"some_arg" => "etc"})
         end
       end
 


### PR DESCRIPTION
Symbol hash keys no longer match:

```sh
1) RefreshSitemapCron when cron tasks are enabled runs Sidekiq job
   Failure/Error: expect(Sidekiq::Worker).to have_enqueued_sidekiq_job(*job_args)

     expected to have an enqueued Sidekiq::Job job
       with arguments:
         -[{}, { "operation" => System::Operation::RefreshSitemap }]
     but have enqueued only jobs
       -JID:26bbd40530c33d72149e21e2 with arguments:
         -[{}, { operation: System::Operation::RefreshSitemap }]
```