### PR TITLE
added required_ruby_version >= 2.7 into gemspec

### DIFF
--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -- lib/*`.split("\n")
   s.files += %w[CHANGES.md LICENSE README.md]
   s.require_paths = ["lib"]
+
+  s.required_ruby_version = ">= 2.7"
 end


### PR DESCRIPTION
With the recent constraint of dropping support for Ruby 2.6 (which also includes JRuby 9.3), the minimum ruby version should be constrained in the gemspec so that it cannot be resolved for older versions.

In addition I would recommend re-releasing `4.0.0, 4.0.1, 4.0.2` gems so that `3.1.0` would be pulled in correctly.