### PR TITLE
Add "immediately" matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ expect(AwesomeJob).to have_enqueued_sidekiq_job(hash_excluding("bad_stuff" => an
 
 #### Testing scheduled jobs
 
-*Use chainable matchers `#at` and `#in`*
+*Use chainable matchers `#at`, `#in` and `#immediately`*
 
 ```ruby
 time = 5.minutes.from_now
@@ -111,6 +111,13 @@ expect(AwesomeJob).to have_enqueued_sidekiq_job('Awesome', true).at(time)
 AwesomeJob.perform_in 5.minutes, 'Awesome', true
 # test with...
 expect(AwesomeJob).to have_enqueued_sidekiq_job('Awesome', true).in(5.minutes)
+```
+
+```ruby
+# Job scheduled for a date in the past are enqueued immediately.
+AwesomeJob.perform_later 5.minutes.ago, 'Awesome', true # equivalent to: AwesomeJob.perform_async 'Awesome', true
+# test with...
+expect(AwesomeJob).to have_enqueued_sidekiq_job('Awesome', true).immediately
 ```
 
 #### Testing queue set for job

--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -16,7 +16,7 @@ module RSpec
         private
 
         def at_evaluator(value)
-          return false if job["at"].to_s.empty?
+          return value.nil? if job["at"].to_s.empty?
           value == Time.at(job["at"]).to_i
         end
 
@@ -182,6 +182,11 @@ module RSpec
 
         def in(interval)
           @expected_options["at"] = (Time.now.to_f + interval.to_f).to_i
+          self
+        end
+
+        def immediately
+          @expected_options["at"] = nil
           self
         end
 

--- a/lib/rspec/sidekiq/matchers/enqueue_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/enqueue_sidekiq_job.rb
@@ -56,7 +56,7 @@ module RSpec
       #
       # Passes if a Job is enqueued as the result of a block. Chainable `with`
       # for arguments, `on` for queue, `at` for queued for a specific time, and
-      # `in` for a specific interval delay to being queued
+      # `in` for a specific interval delay to being queued, `immediately` for queued without delay.
       #
       # @example
       #
@@ -79,6 +79,11 @@ module RSpec
       #   freeze_time do
       #     expect { AwesomeJob.perform_in(1.hour) }.to enqueue_sidekiq_job.in(1.hour)
       #   end
+      #
+      #   # Without any delay
+      #   expect { AwesomeJob.perform_async }.to enqueue_sidekiq_job.immediately
+      #   expect { AwesomeJob.perform_at(1.hour.ago) }.to enqueue_sidekiq_job.immediately
+
       def enqueue_sidekiq_job(job_class = nil)
         EnqueueSidekiqJob.new(job_class)
       end

--- a/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
@@ -177,6 +177,26 @@ RSpec.describe RSpec::Sidekiq::Matchers::EnqueueSidekiqJob do
       end
     end
 
+    context "immediately" do
+      it "passes if the job is enqueued immediately" do
+        expect { worker.perform_async }.to enqueue_sidekiq_job.immediately
+        expect { worker.perform_at(1.hour.ago) }.to enqueue_sidekiq_job.immediately
+      end
+
+      it "fails if the job is scheduled" do
+        specific_time = 1.hour.from_now
+        expect do
+          expect { worker.perform_at(specific_time) }.to enqueue_sidekiq_job.immediately
+        end.to raise_error { |error|
+          lines = error.message.split("\n")
+          expect(lines).to include(
+            match(/expected to have an enqueued .* job/),
+            match(/-{"at"=>nil}/)
+          )
+        }
+      end
+    end
+
     describe "chainable" do
       it "can chain expectations on the job" do
         specific_time = 1.hour.from_now


### PR DESCRIPTION
### The issue

There is currently no way to check whether a job was scheduled for some point in the future, or enqueued immediately.
Specifically, we can't use `have_enqueued_sidekiq_job.at( ... )` if a job was enqueued immediately.

This is because when Sidekiq doesn't add a `"at"` option when the date was in the past, which rspec-sidekiq currently relies on:
https://github.com/sidekiq/sidekiq/blob/bd1ca2b94ad73abdfd4347c83be527bb3ff60acb/lib/sidekiq/job.rb#L328C1-L329

### This PR

This PR enables this:

```ruby
# MyJob will enqueued by Sidekiq immediately by Sidekiq, not scheduled.
# It is equivalent to writing `MyJob.perform_async("hello")`
MyJob.perform_at(5.seconds.ago, "hello")

expect(MyJob).to have_enqueued_sidekiq_job("hello").immediately # passes
``` 
