### PR TITLE
Drop CI for Ruby 2.7 (EOL)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'


### PR DESCRIPTION
Ruby 2.7 reach EOL in November. While the latest versions officially still support Ruby 2.7, the next release of rspec-sidekiq will drop support for Ruby 2.7