### PR TITLE
Fix: require matchers explicitly

### DIFF
--- a/lib/rspec/sidekiq/matchers.rb
+++ b/lib/rspec/sidekiq/matchers.rb
@@ -1,4 +1,5 @@
 require "rspec/core"
+require "rspec/matchers"
 require "rspec/mocks/argument_list_matcher"
 require "rspec/mocks/argument_matchers"
 


### PR DESCRIPTION
Rails autoloading was probably saving most of us, but an explicit require for Composable is best.