### PR TITLE
Support `have_enqueued_sidekiq_job` with no args

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 Unreleased
 ---
+* [BREAKING] Make `have_enqueued_sidekiq_job()` match jobs with any arguments (same as `enqueue_sidekiq_job()` or `have_enqueued_sidekiq_job(any_args)`) ([@3v0k4](https://github.com/3v0k4) #215)
 
 4.2.0
 ---
-* Add warning about `have_enqueued_sidekiq_job` with no arguments (default will
-  change in next major release) (#216, #217)
+* Add warning about `have_enqueued_sidekiq_job` with no arguments (default will change in next major release) (#216, #217)
 
 4.1.0
 ---

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ end.to enqueue_sidekiq_job(AwesomeJob).and enqueue_sidekiq_job(OtherJob)
 
 ### have_enqueued_sidekiq_job
 
-Describes that there should be an enqueued job with the **specified arguments**
+Describes that there should be an enqueued job (with the specified arguments):
 
 ```ruby
 AwesomeJob.perform_async 'Awesome', true
 # test with...
+expect(AwesomeJob).to have_enqueued_sidekiq_job
 expect(AwesomeJob).to have_enqueued_sidekiq_job('Awesome', true)
 ```
 
@@ -164,29 +165,6 @@ expect(Sidekiq::Worker).to have_enqueued_sidekiq_job(
   user,
   true
 )
-```
-
-#### Testing a job is _not_ enqueued
-
-The negative case for `have_enqueued_sidekiq_job` is provided, but it's
-important to remember that `have_enqueued_sidekiq_job` is an expectation that a
-job is enqueued _with specific arguments_. In other words, passing no arguments
-to `have_enqueued_sidekiq_job` is implicitly telling the matcher to look for
-jobs _without_ arguments.
-
-In short, unless you tell the matcher that _no_ jobs with _any_ arguments should be enqueued, you'll get the wrong result:
-
-```ruby
-# example this is a test that we'd expect to fail
-AwesomeJob.perform_async "Actually not awesome"
-
-### BAD - saying there shouldn't be a job enqueued _without_ args
-expect(AwesomeJob).not_to have_enqueued_sidekiq_job
-# => passes! 😱 Our job was enqueued _with_ args so no job exists without args.
-
-### Good
-expect(AwesomeJob).not_to have_enqueued_sidekiq_job(any_args)
-# => fails
 ```
 
 ### be_processed_in

--- a/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
@@ -7,18 +7,8 @@ module RSpec
 
       # @api private
       class HaveEnqueuedSidekiqJob < Base
-        DEPRECATION = [
-          "[WARNING] `have_enqueued_sidekiq_job()` without arguments default behavior will change in next major release.",
-          "Use `have_enqueued_sidekiq_job(no_args)` to maintain legacy behavior.",
-          "More available here: https://github.com/wspurgin/rspec-sidekiq/wiki/have_enqueued_sidekiq_job-without-argument-default-behavior"
-        ].join(" ").freeze
-
         def initialize(expected_arguments)
           super()
-
-          if expected_arguments == [] && RSpec::Sidekiq.configuration.warn_for?(:have_enqueued_sidekiq_job_default)
-            Kernel.warn(DEPRECATION, uplevel: 3)
-          end
           @expected_arguments = normalize_arguments(expected_arguments)
         end
 
@@ -26,7 +16,11 @@ module RSpec
           @klass = job_class
 
           @actual_jobs = EnqueuedJobs.new(klass)
-          actual_jobs.includes?(expected_arguments, expected_options)
+
+          actual_jobs.includes?(
+            expected_arguments == [] ? any_args : expected_arguments,
+            expected_options
+          )
         end
       end
     end


### PR DESCRIPTION
First of all, thanks for your work on `rspec-sidekiq`, it helped cleaning up our tests tremendously!

---

When I started using `rspec-sidekiq`, I assumed it would work similarly to the builtin matchers.

For example, the negation of `raise_error` works as follows:

```ruby
expect { raise StandardError.new("arg") }.not_to raise_error(StandardError, 'arg') # expects StandardError with "arg"
expect { raise StandardError.new("arg") }.not_to raise_error(StandardError) # expects `StandardError`
expect { raise StandardError.new("arg") }.not_to raise_error # expects any exception
```

In the case of `rspec-sidekiq`, it's different:

```ruby
expect(AwesomeJob).not_to have_enqueued_sidekiq_job # expects no jobs with no args (instead of any job)
expect(AwesomeJob).not_to have_enqueued_sidekiq_job("arg") # expects no jobs with "arg"
```

I believe the need for more documentation on this (https://github.com/wspurgin/rspec-sidekiq/commit/603b9) stems from the confusing semantics.

It's especially important to provide loose matching for the negative case because it may give a sense of false confidence (I was bitten by this):

```ruby
# Initially, I TDD the following code

expect(AwesomeJob).not_to have_enqueued_sidekiq_job

if false
  AwesomeJob.perform_async
end


# Later, I add some args to `AwesomeJob` and mess up the conditional

if true
  AwesomeJob.perform_async "arg"
end

# ⛔️ The test still passes (because it lacks `(any_args)` or `("arg")`)
```

I'd argue it's a better default to check for any jobs enqueued instead of jobs with no arguments.

This change applies to both `expect(Job).not_to have_enqueued_sidekiq_job` and `expect(Job).to have_enqueued_sidekiq_job`, but we could apply it only to the negative case if you prefer.

I'm happy to discuss alternatives if you think this is an issue but don't like the specific solution.

I guess in the longer term, `enqueue_sidekiq_job` and `have_enqueued_sidekiq_job` could have the same API:

```
enqueue_sidekiq_job == have_enqueued_sidekiq_job
enqueue_sidekiq_job.with("Awesome!") == have_enqueued_sidekiq_job.with("Awesome!")
```