### PR TITLE
Deprecate `have_enqueued_sidekiq_job` with no arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Unreleased
+---
+* Deprecate `have_enqueued_sidekiq_job` with no arguments (use either `have_enqueued_sidekiq_job(no_args)` or `have_enqueued_sidekiq_job(any_args)`) ([@3v0k4](https://github.com/3v0k4))
+
 4.1.0
 ---
 * Add Composable support to `enqueue_sidekiq_job` and

--- a/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
@@ -7,6 +7,11 @@ module RSpec
 
       # @api private
       class HaveEnqueuedSidekiqJob < Base
+        DEPRECATION = [
+          "[DEPRECATION] `have_enqueued_sidekiq_job()` is deprecated.",
+          "Please use either `have_enqueued_sidekiq_job(no_args)` or `have_enqueued_sidekiq_job(any_args)`."
+        ].join(" ")
+
         def initialize(expected_arguments)
           super()
           @expected_arguments = normalize_arguments(expected_arguments)
@@ -17,6 +22,7 @@ module RSpec
 
           @actual_jobs = EnqueuedJobs.new(klass)
 
+          warn DEPRECATION if expected_arguments == []
           actual_jobs.includes?(expected_arguments, expected_options)
         end
       end

--- a/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
         expect(worker).to have_enqueued_sidekiq_job *worker_args
       end
 
+      it 'matches with no arguments but prints a warning' do
+        worker.perform_async
+        expect {
+          expect(worker).to have_enqueued_sidekiq_job
+        }.to output(/[DEPRECATION]/).to_stderr
+      end
+
+      it 'matches with no_args' do
+        worker.perform_async
+        expect(worker).to have_enqueued_sidekiq_job(no_args)
+      end
+
       it 'matches on the global Worker queue' do
         worker.perform_async *worker_args
         expect(Sidekiq::Worker).to have_enqueued_sidekiq_job *worker_args


### PR DESCRIPTION
Deprecate `have_enqueued_sidekiq_job` with no arguments to release a new version in preparation for #215