### PR TITLE
Prep for 5.0 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up using Ruby ${{ matrix.ruby-version }} with Gemfile '${{ matrix.gemfile }}'
-      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-      # change this to (see https://github.com/ruby/setup-ruby#versioning):
-      # uses: ruby/setup-ruby@v1
-        uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,11 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - '3.0'
-          - '3.1'
+          - '3.3'
           - '3.2'
+          - '3.1'
+          - '3.0'
+          - '2.7'
         gemfile:
           - 'Gemfile'
           - 'gemfiles/sidekiq5_rails6.gemfile'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 Unreleased
 ---
+
+5.0.0
+---
 * [BREAKING] Make `have_enqueued_sidekiq_job()` match jobs with any arguments (same as `enqueue_sidekiq_job()` or `have_enqueued_sidekiq_job(any_args)`) (#215)
 * Add support for expected number of jobs to both `enqueue_sidekiq_job` and `have_enqueued_sidekiq_job` (#219)
 

--- a/lib/rspec/sidekiq/version.rb
+++ b/lib/rspec/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Sidekiq
-    VERSION = "4.2.0"
+    VERSION = "5.0.0"
   end
 end


### PR DESCRIPTION
🧹 just some house keeping before releasing 5.0 with the (albeit small) breaking change of behavior to `have_enqueued_sidekiq_job()`