### PR TITLE
Add frozen_string_literal: true everywhere

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ name: main build
 run-name: ${{ github.actor }} 🚀 ${{github.ref_name}}
 on:
   push:
+    branches:
+      - 'main'
   pull_request:
   schedule:
     - cron: '30 15 * * *'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ name: main build
 run-name: ${{ github.actor }} 🚀 ${{github.ref_name}}
 on:
   push:
-    branches:
-      - 'main'
   pull_request:
   schedule:
     - cron: '30 15 * * *'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up using Ruby ${{ matrix.ruby-version }} with Gemfile '${{ matrix.gemfile }}'
         uses: ruby/setup-ruby@v1
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* Add `frozen_string_literal: true` (#220)
 
 5.0.0
 ---

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 platforms :rbx do

--- a/gemfiles/sidekiq5_rails6.gemfile
+++ b/gemfiles/sidekiq5_rails6.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'sidekiq', '~> 5.0'

--- a/gemfiles/sidekiq6_4_rails6.gemfile
+++ b/gemfiles/sidekiq6_4_rails6.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'sidekiq', '~> 6.4.0'

--- a/gemfiles/sidekiq6_4_rails7.gemfile
+++ b/gemfiles/sidekiq6_4_rails7.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'sidekiq', '~> 6.4.0'

--- a/gemfiles/sidekiq6_5_rails6.gemfile
+++ b/gemfiles/sidekiq6_5_rails6.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'sidekiq', '~> 6.5'

--- a/gemfiles/sidekiq6_5_rails7.gemfile
+++ b/gemfiles/sidekiq6_5_rails7.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'sidekiq', '~> 6.5'

--- a/gemfiles/sidekiq7_rails7.gemfile
+++ b/gemfiles/sidekiq7_rails7.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'sidekiq', '~> 7'

--- a/lib/rspec-sidekiq.rb
+++ b/lib/rspec-sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 require 'sidekiq'

--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/core'
 
 if defined? Sidekiq::Batch

--- a/lib/rspec/sidekiq/configuration.rb
+++ b/lib/rspec/sidekiq/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubygems"
 require "set"
 

--- a/lib/rspec/sidekiq/helpers.rb
+++ b/lib/rspec/sidekiq/helpers.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'rspec/core'
 require 'rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block'

--- a/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
+++ b/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sidekiq
   module Worker
     module ClassMethods

--- a/lib/rspec/sidekiq/matchers.rb
+++ b/lib/rspec/sidekiq/matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/core"
 require "rspec/matchers"
 require "rspec/mocks/argument_list_matcher"

--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -277,7 +277,7 @@ module RSpec
             message << "but enqueued only jobs"
             if expected_arguments
               job_messages = actual_jobs.map do |job|
-                base = "  -JID:#{job.jid} with arguments:"
+                base = +"  -JID:#{job.jid} with arguments:"
                 base << "\n    -#{formatted(job.args)}"
                 if expected_options.any?
                   base << "\n   with context: #{formatted(job.context)}"

--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -277,13 +277,13 @@ module RSpec
             message << "but enqueued only jobs"
             if expected_arguments
               job_messages = actual_jobs.map do |job|
-                base = +"  -JID:#{job.jid} with arguments:"
-                base << "\n    -#{formatted(job.args)}"
+                base = ["  -JID:#{job.jid} with arguments:"]
+                base << "    -#{formatted(job.args)}"
                 if expected_options.any?
-                  base << "\n   with context: #{formatted(job.context)}"
+                  base << "   with context: #{formatted(job.context)}"
                 end
 
-                base
+                base.join("\n")
               end
 
               message << job_messages.join("\n")

--- a/lib/rspec/sidekiq/matchers/be_delayed.rb
+++ b/lib/rspec/sidekiq/matchers/be_delayed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/be_expired_in.rb
+++ b/lib/rspec/sidekiq/matchers/be_expired_in.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/be_processed_in.rb
+++ b/lib/rspec/sidekiq/matchers/be_processed_in.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/be_retryable.rb
+++ b/lib/rspec/sidekiq/matchers/be_retryable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/enqueue_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/enqueue_sidekiq_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_sidekiq_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/matchers/save_backtrace.rb
+++ b/lib/rspec/sidekiq/matchers/save_backtrace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Matchers

--- a/lib/rspec/sidekiq/sidekiq.rb
+++ b/lib/rspec/sidekiq/sidekiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     class << self

--- a/lib/rspec/sidekiq/version.rb
+++ b/lib/rspec/sidekiq/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     VERSION = "5.0.0"

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path("../lib/rspec/sidekiq/version", __FILE__)
 
 Gem::Specification.new do |s|

--- a/spec/rspec/sidekiq/batch_spec.rb
+++ b/spec/rspec/sidekiq/batch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Batch', stub_batches: true do

--- a/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
+++ b/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Retries Exhausted block' do

--- a/spec/rspec/sidekiq/matchers/be_delayed_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_delayed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe RSpec::Sidekiq::Matchers::BeDelayed do

--- a/spec/rspec/sidekiq/matchers/be_expired_in_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_expired_in_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::BeExpiredIn do

--- a/spec/rspec/sidekiq/matchers/be_processed_in_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_processed_in_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::BeProcessedIn do

--- a/spec/rspec/sidekiq/matchers/be_retryable_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_retryable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::BeRetryable do

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do

--- a/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 RSpec.describe RSpec::Sidekiq::Matchers::EnqueueSidekiqJob do

--- a/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
@@ -123,18 +123,18 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
       end
 
       it 'matches a job with arguments' do
-        worker.perform_async *worker_args
+        worker.perform_async(*worker_args)
         expect(worker).to have_enqueued_sidekiq_job
-        expect(worker).to have_enqueued_sidekiq_job *worker_args
+        expect(worker).to have_enqueued_sidekiq_job(*worker_args)
       end
 
       it 'matches on the global Worker queue' do
-        worker.perform_async *worker_args
-        expect(Sidekiq::Worker).to have_enqueued_sidekiq_job *worker_args
+        worker.perform_async(*worker_args)
+        expect(Sidekiq::Worker).to have_enqueued_sidekiq_job(*worker_args)
       end
 
       it "fails if a job was enqueued with arguments but matched with no_args" do
-        worker.perform_async *worker_args
+        worker.perform_async(*worker_args)
         expect do
           expect(worker).to have_enqueued_sidekiq_job(no_args)
         end.to raise_error(/expected to have enqueued a .* job/)
@@ -149,7 +149,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
         end
 
         it "fails if a job was enqueued" do
-          worker.perform_async *worker_args
+          worker.perform_async(*worker_args)
           expect do
             expect(worker).not_to have_enqueued_sidekiq_job
           end.to raise_error(/expected not to have enqueued a .* job/)
@@ -257,19 +257,19 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
 
   describe '#have_enqueued_sidekiq_job' do
     it 'returns instance' do
-      worker.perform_async *worker_args
+      worker.perform_async(*worker_args)
       expect(have_enqueued_sidekiq_job).to be_a described_class
     end
 
     it 'matches the same way have_enqueued_sidekiq_job does' do
-      worker.perform_async *worker_args
-      expect(worker).to have_enqueued_sidekiq_job *worker_args
+      worker.perform_async(*worker_args)
+      expect(worker).to have_enqueued_sidekiq_job(*worker_args)
     end
   end
 
   describe '#description' do
     it 'returns description' do
-      worker.perform_async *worker_args
+      worker.perform_async(*worker_args)
       argument_subject.matches? worker
       expect(argument_subject.description).to eq %{have enqueued a #{worker} job with arguments [\"string\", 1, true, {\"key\"=>\"value\", \"bar\"=>\"foo\", \"nested\"=>[{\"hash\"=>true}]}]}
     end
@@ -277,7 +277,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
 
   describe '#failure_message' do
     it 'returns message' do
-      jid = worker.perform_async *worker_args
+      jid = worker.perform_async(*worker_args)
       argument_subject.matches? worker
       expect(argument_subject.failure_message).to eq <<~eos.strip
       expected to have enqueued a #{worker} job
@@ -294,7 +294,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
       let(:argument_subject) { described_class.new wrapped_args }
 
       it "returns a message showing the wrapped array in expectations but each job on its own line" do
-        jids = 2.times.map { worker.perform_async *worker_args }
+        jids = 2.times.map { worker.perform_async(*worker_args) }
         argument_subject.matches? worker
         expect(argument_subject.failure_message).to eq <<~eos.strip
         expected to have enqueued a #{worker} job
@@ -312,7 +312,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
 
   describe '#failure_message_when_negated' do
     it 'returns message' do
-      worker.perform_async *worker_args
+      worker.perform_async(*worker_args)
       argument_subject.matches? worker
       expect(argument_subject.failure_message_when_negated).to eq <<-eos.gsub(/^ {6}/, '').strip
       expected not to have enqueued a #{worker} job but enqueued 1
@@ -325,7 +325,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
     context 'when condition matches' do
       context 'when expected are arguments' do
         it 'returns true' do
-          worker.perform_async *worker_args
+          worker.perform_async(*worker_args)
           expect(argument_subject.matches? worker).to be true
         end
       end
@@ -340,7 +340,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
 
       context 'when expected are matchers' do
         it 'returns true' do
-          worker.perform_async *worker_args
+          worker.perform_async(*worker_args)
           expect(matcher_subject.matches? worker).to be true
         end
       end

--- a/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do

--- a/spec/rspec/sidekiq/matchers/save_backtrace_spec.rb
+++ b/spec/rspec/sidekiq/matchers/save_backtrace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::SaveBacktrace do

--- a/spec/rspec/sidekiq/sidekiq_spec.rb
+++ b/spec/rspec/sidekiq/sidekiq_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pry'
 
 require 'sidekiq'

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RSpec
   module Sidekiq
     module Spec

--- a/spec/support/init.rb
+++ b/spec/support/init.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'factories'
 require_relative 'test_worker'
 require_relative 'test_worker_alternative'

--- a/spec/support/test_action_mailer.rb
+++ b/spec/support/test_action_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestActionMailer < ActionMailer::Base
   def  testmail(resource = nil)
     @resource = resource

--- a/spec/support/test_job.rb
+++ b/spec/support/test_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestJob < ActiveJob::Base
   queue_as :mailers
 

--- a/spec/support/test_resource.rb
+++ b/spec/support/test_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestResource
   include GlobalID::Identification
 

--- a/spec/support/test_worker.rb
+++ b/spec/support/test_worker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestWorker
   include Sidekiq::Worker
 

--- a/spec/support/test_worker_alternative.rb
+++ b/spec/support/test_worker_alternative.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestWorkerAlternative
   include Sidekiq::Worker
 


### PR DESCRIPTION
Since [Ruby 3.4 ](https://www.ruby-lang.org/en/news/2024/05/16/ruby-3-4-0-preview1-released/) will consider String literals in files without a frozen_string_literal comment as if they were frozen, I took the opportunity to add its.
