### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |s|
   s.description = "Simple testing of Sidekiq jobs via a collection of matchers and helpers"
   s.license     = "MIT"
 
+  s.metadata = {
+    "changelog_uri" => "https://github.com/wspurgin/rspec-sidekiq/blob/main/CHANGES.md"
+  }
+
   s.add_dependency "rspec-core", "~> 3.0"
   s.add_dependency "rspec-mocks", "~> 3.0"
   s.add_dependency "rspec-expectations", "~> 3.0"


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata 

Useful for running https://github.com/MaximeD/gem_updater