### PR TITLE
Fix pattern matching warnings on Ruby 2.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 Unreleased
 ---
 * Add `frozen_string_literal: true` (#220)
+* Fix pattern matching warnings on Ruby 2.7 (#227)
 
 5.0.0
 ---

--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -123,13 +123,13 @@ module RSpec
         def includes?(arguments, options, count)
           matching = jobs.filter { |job| matches?(job, arguments, options) }
 
-          case count
-          in [:exactly, n]
-            matching.size == n
-          in [:at_least, n]
-            matching.size >= n
-          in [:at_most, n]
-            matching.size <= n
+          case count[0]
+          when :exactly
+            matching.size == count[1]
+          when :at_least
+            matching.size >= count[1]
+          when :at_most
+            matching.size <= count[1]
           else
             matching.size > 0
           end
@@ -304,13 +304,13 @@ module RSpec
         end
 
         def count_message
-          case expected_count
-          in [:positive, _]
+          case expected_count[0]
+          when :positive
             "a"
-          in [:exactly, n]
-            n
-          in [relativity, n]
-            "#{relativity.to_s.gsub('_', ' ')} #{n}"
+          when :exactly
+            expected_count[1]
+          else
+            "#{expected_count[0].to_s.gsub('_', ' ')} #{expected_count[1]}"
           end
         end
 


### PR DESCRIPTION
- Resolves https://github.com/wspurgin/rspec-sidekiq/issues/226

How about changing the code to one that doesn't use pattern-matching? I don't think the benefit from this pattern-matching was that great, and if this level of change will help Ruby 2.7 users, I consider this an acceptable change.