### PR TITLE
Worker is dead term

### DIFF
--- a/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
+++ b/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
@@ -10,7 +10,7 @@ module Sidekiq
 
       def default_retries_exhausted_message
         {
-          'queue' => get_sidekiq_options[:worker],
+          'queue' => get_sidekiq_options['queue'],
           'class' => name,
           'args' => [],
           'error_message' => 'An error occurred'

--- a/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
+++ b/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
@@ -13,12 +13,12 @@ module Sidekiq
           'queue' => get_sidekiq_options[:worker],
           'class' => name,
           'args' => [],
-          'error_message' => 'An error occured'
+          'error_message' => 'An error occurred'
         }
       end
 
       def default_retries_exhausted_exception
-        StandardError.new('An error occured')
+        StandardError.new('An error occurred')
       end
     end
   end

--- a/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
+++ b/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
@@ -20,6 +20,15 @@ RSpec.describe 'Retries Exhausted block' do
     end
   end
 
+  it 'has an exhausted message' do
+    expect(FooClass.default_retries_exhausted_message).to eq({
+                                                               "args" => [],
+                                                               "class" => "FooClass",
+                                                               "error_message" => "An error occurred",
+                                                               "queue" => "data",
+                                                             })
+  end
+
   it 'executes whatever is within the block' do
     FooClass.within_sidekiq_retries_exhausted_block { expect(FooClass).to receive(:bar).with('hello') }
   end


### PR DESCRIPTION
🐛 Queue always nil in default_retries_exhausted_message

- worker is no longer used in most scenarios
  - See: https://github.com/sidekiq/sidekiq/wiki/Best-Practices#4-use-precise-terminology
- keys are string, symbol lookups fail
- Add test