### PR TITLE
Sidekiq Enterprise: until matcher

### DIFF
--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -29,7 +29,7 @@ module RSpec
               "but its interval was #{actual_interval} seconds"
             elsif !expiration_matches?
               "expected #{@klass} to be unique until #{@expected_expiration}, "\
-              "but its unique_until was #{actual_expiration}"
+              "but its unique_until was #{actual_expiration || 'not specified'}"
             else
               "expected #{@klass} to be unique in the queue"
             end

--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -73,6 +73,10 @@ module RSpec
             @klass.get_sidekiq_options['unique_job_expiration']
           end
 
+          def actual_expiration
+            fail 'until is not supported for SidekiqUniqueJobs'
+          end
+
           def value_matches?
             [true, :all].include?(@actual)
           end

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
   end
 
   context '.until' do
-    before { stub_const("Sidekiq::Enterprise", true) }
-
+    let(:module_constant) { "Sidekiq::Enterprise" }
     let(:expiration) { :success }
     let(:interval) { 3.hours }
+    let(:sidekiq_options) { { unique_for: interval, unique_until: expiration } }
     let(:worker) do
-      options = { unique_for: interval, unique_until: expiration }
+      options = sidekiq_options
       Class.new do
         include ::Sidekiq::Worker
         sidekiq_options options
@@ -69,8 +69,9 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
       end
     end
 
+    before { stub_const(module_constant, true) }
+
     subject do
-      stub_const("Sidekiq::Enterprise", true)
       stub_const('MuhWorker', worker)
       MuhWorker
     end
@@ -78,7 +79,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
     it { should be_unique.for(interval).until(:success) }
 
     context 'errors' do
-      subject { expect(super()).to be_unique.for(interval).until(:started) }
+      subject { expect(super()).to be_unique.until(:started) }
 
       context 'when there is a mismatch' do
         it do
@@ -94,6 +95,13 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
           expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
             'expected MuhWorker to be unique until started, but its unique_until was not specified'
         end
+      end
+
+      context 'when unique_until is not supported' do
+        let(:module_constant) { "SidekiqUniqueJobs" }
+        let(:sidekiq_options) { { unique: interval } }
+
+        it { expect { subject }.to raise_error 'until is not supported for SidekiqUniqueJobs' }
       end
     end
   end

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -55,6 +55,38 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
     include_context 'a unique worker'
   end
 
+  context '.until' do
+    before { stub_const("Sidekiq::Enterprise", true) }
+
+    let(:expiration) { :success }
+    let(:interval) { 3.hours }
+    let(:worker) do
+      options = { unique_for: interval, unique_until: expiration }
+      Class.new do
+        include ::Sidekiq::Worker
+        sidekiq_options options
+        def perform; end
+      end
+    end
+
+    subject do
+      stub_const("Sidekiq::Enterprise", true)
+      stub_const('MuhWorker', worker)
+      MuhWorker
+    end
+
+    it { should be_unique.for(interval).until(:success) }
+
+    context 'failure' do
+      subject { expect(super()).to be_unique.for(interval).until(:started) }
+
+      it do
+        expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
+          'expected MuhWorker to be unique until started, but its unique_until was success'
+      end
+    end
+  end
+
   context 'a sidekiq-unique-jobs scheduled worker' do
     let(:module_constant) { "SidekiqUniqueJobs" }
     before { @worker = create_worker unique: :all }

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -77,12 +77,23 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
 
     it { should be_unique.for(interval).until(:success) }
 
-    context 'failure' do
+    context 'errors' do
       subject { expect(super()).to be_unique.for(interval).until(:started) }
 
-      it do
-        expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
-          'expected MuhWorker to be unique until started, but its unique_until was success'
+      context 'when there is a mismatch' do
+        it do
+          expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
+            'expected MuhWorker to be unique until started, but its unique_until was success'
+        end
+      end
+
+      context 'when not specified' do
+        let(:expiration) { nil }
+
+        it do
+          expect { subject }.to raise_error RSpec::Expectations::ExpectationNotMetError,
+            'expected MuhWorker to be unique until started, but its unique_until was not specified'
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

In Sidekiq Enterprise's [Unique Jobs](https://github.com/mperham/sidekiq/wiki/Ent-Unique-Jobs#unlock-policy) feature, you have the ability to specify an unlock policy.

This PR adds an until matcher so that you may specify an expectation against a worker for it like so:

```ruby
describe MuhWorker do
  it { should be_unique.until(:success) }
end
```

It also will fail that it is not supported if a user tries to use it with SidekiqUniqueJobs.

(all credit to @leviwilson for his work on this, I just rebased and brought it current)