### PR TITLE
Support for Sidekiq 8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,14 @@ jobs:
           - 'gemfiles/sidekiq6_5_rails6.gemfile'
           - 'gemfiles/sidekiq6_5_rails7.gemfile'
           - 'gemfiles/sidekiq7_rails7.gemfile'
+          - 'gemfiles/sidekiq8_rails8.gemfile'
+        exclude:
+          - ruby-version: '3.1'
+            gemfile: 'gemfiles/sidekiq8_rails8.gemfile'
+          - ruby-version: '3.0'
+            gemfile: 'gemfiles/sidekiq8_rails8.gemfile'
+          - ruby-version: '2.7'
+            gemfile: 'gemfiles/sidekiq8_rails8.gemfile'
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:

--- a/gemfiles/sidekiq8_rails8.gemfile
+++ b/gemfiles/sidekiq8_rails8.gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'sidekiq', '~> 8'
+gem 'activejob', '~> 8'
+gem 'actionmailer', '~> 8'
+gem 'activerecord', '~> 8'
+gem "activemodel", "~> 8"
+gem "railties", "~> 8"
+
+gemspec :path => '../'

--- a/lib/rspec/sidekiq/configuration.rb
+++ b/lib/rspec/sidekiq/configuration.rb
@@ -24,6 +24,10 @@ module RSpec
         Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new("7.0.0")
       end
 
+      def sidekiq_gte_8?
+        Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
+      end
+
       def silence_warning(symbol)
         @silence_warnings << symbol
       end

--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -60,7 +60,11 @@ module RSpec
         private
 
         def active_job?
-          job["class"] == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+          if RSpec::Sidekiq.configuration.sidekiq_gte_8?
+            job["class"] == "Sidekiq::ActiveJob::Wrapper"
+          else
+            job["class"] == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+          end
         end
 
         def deserialized_active_job_args

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rspec-core", "~> 3.0"
   s.add_dependency "rspec-mocks", "~> 3.0"
   s.add_dependency "rspec-expectations", "~> 3.0"
-  s.add_dependency "sidekiq", ">= 5", "< 8"
+  s.add_dependency "sidekiq", ">= 5", "< 9"
 
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-doc"
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activerecord"
   s.add_development_dependency "activemodel"
   s.add_development_dependency "activesupport"
+  s.add_development_dependency "railties"
 
   s.files = `git ls-files -- lib/*`.split("\n")
   s.files += %w[CHANGES.md LICENSE README.md]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ RSpec.configure do |config|
   config.sidekiq_gte_7 = Gem::Dependency.new("sidekiq", ">= 7.0.0").matching_specs.any?
 
   config.before(:suite) do
+    require "sidekiq/rails" if config.sidekiq_gte_7
     ActiveJob::Base.queue_adapter = :sidekiq
     ActiveJob::Base.logger.level = :warn
 


### PR DESCRIPTION
- Fixed CI failing with
```
An error occurred in a `before(:suite)` hook.
Failure/Error: ActiveJob::Base.queue_adapter = :sidekiq

NameError:
  uninitialized constant Sidekiq::ActiveJob
```
by requiring `sidekiq/rails` and added `railties` as dev dependency
- Added new gemfile for Sidekiq 8 & Rails 8
- Added support for Sidekiq 8 (https://github.com/sidekiq/sidekiq/blob/main/Changes.md#800)