### PR TITLE
fix matcher to support exactly(0)

### DIFF
--- a/lib/rspec/sidekiq/matchers/enqueue_sidekiq_job.rb
+++ b/lib/rspec/sidekiq/matchers/enqueue_sidekiq_job.rb
@@ -25,10 +25,6 @@ module RSpec
           proc.call
           @actual_jobs = EnqueuedJobs.new(@klass).minus!(original_jobs)
 
-          if @actual_jobs.none?
-            return false
-          end
-
           @actual_jobs.includes?(expected_arguments, expected_options, expected_count)
         end
 

--- a/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
@@ -300,6 +300,15 @@ RSpec.describe RSpec::Sidekiq::Matchers::EnqueueSidekiqJob do
     end
 
     context "with expected count" do
+      it "zero" do
+        expect {
+          "does nothing"
+        }.to enqueue_sidekiq_job.exactly(0)
+        expect {
+          "does nothing"
+        }.to enqueue_sidekiq_job.exactly(0).time
+      end
+
       it 'matches a job with no arguments once' do
         expect { worker.perform_async }.to enqueue_sidekiq_job.once
       end

--- a/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_sidekiq_job_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedSidekiqJob do
 
   describe 'expected usage' do
     context 'Sidekiq' do
+      it 'matches no job' do
+        expect(worker).to have_enqueued_sidekiq_job.exactly(0)
+        expect(worker).to have_enqueued_sidekiq_job.exactly(0).time
+      end
+
       it 'matches a job with no arguments' do
         worker.perform_async
         expect(worker).to have_enqueued_sidekiq_job


### PR DESCRIPTION
Currently
```
expect { 'do nothing' }.to enqueue_sidekiq_job(SomeJob).exactly(0)
```

will result in
```
 expected to enqueue 0 SomeJob jobs
   with arguments:
     -[*(any args)]
 but enqueued 0 jobs
```
which I believe is not expected behavior.
