### PR TITLE
Delete the unnecessary .rubocop.yml file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,0 @@
-LineLength:
-  Max: 140


### PR DESCRIPTION
RuboCop is not currently used in this project.