### PR TITLE
Replace pry with debug in development dependencies

### DIFF
--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -21,9 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rspec-expectations", "~> 3.0"
   s.add_dependency "sidekiq", ">= 5", "< 9"
 
-  s.add_development_dependency "pry"
-  s.add_development_dependency "pry-doc"
-  s.add_development_dependency "pry-nav"
+  s.add_development_dependency "debug"
   s.add_development_dependency "rspec"
   s.add_development_dependency "coveralls"
   s.add_development_dependency "fuubar"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pry'
+require 'debug'
 
 require 'sidekiq'
 require 'rspec-sidekiq'


### PR DESCRIPTION
I don't have a strong opinion, but in most cases I think it is better to use what is provided by Ruby org. https://github.com/ruby/debug