### PR TITLE
Change rspec command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,6 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run tests
-        run: bundle exec rspec spec
+        run: bundle exec rspec
       - name: Check for implicitly loaded dependencies # See #204
         run: bundle exec ruby ./lib/rspec-sidekiq.rb

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ FooClass.within_sidekiq_retries_exhausted_block {
 
 ## Testing
 ```
-bundle exec rspec spec
+bundle exec rspec
 ```
 
 ## Maintainers


### PR DESCRIPTION
`spec` is unnecessary.

```
~/ydah/rspec-sidekiq remove-example
❯ bundle exec rspec spec
[rspec-sidekiq] WARNING! Sidekiq will *NOT* process jobs in this environment. See https://github.com/wspurgin/rspec-sidekiq/wiki/FAQ-&-Troubleshooting
..2025-06-19T09:02:47.940Z pid=56574 tid=15tu INFO: Sidekiq 7.3.9 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>nil}
.................................................................................................................................................................................................

Finished in 0.10617 seconds (files took 0.54088 seconds to load)
195 examples, 0 failures

~/ydah/rspec-sidekiq remove-example
❯ bundle exec rspec
[rspec-sidekiq] WARNING! Sidekiq will *NOT* process jobs in this environment. See https://github.com/wspurgin/rspec-sidekiq/wiki/FAQ-&-Troubleshooting
..2025-06-19T09:02:50.611Z pid=56706 tid=15em INFO: Sidekiq 7.3.9 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>nil}
.................................................................................................................................................................................................

Finished in 0.08648 seconds (files took 0.37149 seconds to load)
195 examples, 0 failures
```