### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,4 @@
 
 source 'https://rubygems.org'
 
-platforms :rbx do
-  gem 'psych'
-  gem 'rubinius-developer_tools'
-end
-
 gemspec

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-doc"
   s.add_development_dependency "pry-nav"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "coveralls"
   s.add_development_dependency "fuubar"
   s.add_development_dependency "activejob"
   s.add_development_dependency "actionmailer"

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-doc"
   s.add_development_dependency "pry-nav"
   s.add_development_dependency "rspec"
-  s.add_development_dependency "fuubar"
   s.add_development_dependency "activejob"
   s.add_development_dependency "actionmailer"
   s.add_development_dependency "activerecord"


### PR DESCRIPTION
- remove platform-specific gems for Rubinius from Gemfile
  - In the past, this gem was necessary because TravisCI supported Rubinius, but it's no longer needed now.
  - Refs: https://github.com/wspurgin/rspec-sidekiq/pull/35/files
- remove coveralls development dependency from gemspec
  - It seems to have been completely disused following:
  - https://github.com/wspurgin/rspec-sidekiq/commit/8fc3f9dca869eb746c88902afe72f2255108524d#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94
- remove fuubar development dependency from gemspec
  - It is not explicitly used now