### PR TITLE
Fix metadata assignment in gemspec for consistency

### DIFF
--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |s|
   s.description = "Simple testing of Sidekiq jobs via a collection of matchers and helpers"
   s.license     = "MIT"
 
-  spec.metadata["homepage_uri"]      = spec.homepage
-  spec.metadata["source_code_uri"]   = spec.homepage
-  spec.metadata["changelog_uri"]     = "#{spec.homepage}/blob/main/CHANGES.md"
-  spec.metadata["bug_tracker_uri"]   = "#{spec.homepage}/issues"
+  s.metadata["homepage_uri"]      = s.homepage
+  s.metadata["source_code_uri"]   = s.homepage
+  s.metadata["changelog_uri"]     = "#{s.homepage}/blob/main/CHANGES.md"
+  s.metadata["bug_tracker_uri"]   = "#{s.homepage}/issues"
 
   s.add_dependency "rspec-core", "~> 3.0"
   s.add_dependency "rspec-mocks", "~> 3.0"


### PR DESCRIPTION
I'm sorry for the mistake.

refs: https://github.com/wspurgin/rspec-sidekiq/actions/runs/15892413409/job/44817328871

```
Did you mean?  inspect. Bundler cannot continue.

 #  from /home/runner/work/rspec-sidekiq/rspec-sidekiq/rspec-sidekiq.gemspec:15
 #  -------------------------------------------
 #  
 >    spec.metadata["homepage_uri"]      = spec.homepage
 #    spec.metadata["source_code_uri"]   = spec.homepage
 #  -------------------------------------------
. Bundler cannot continue.

```