### PR TITLE
Remove unnecessary methods for silence warnings

### DIFF
--- a/lib/rspec/sidekiq/configuration.rb
+++ b/lib/rspec/sidekiq/configuration.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rubygems"
-require "set"
 
 module RSpec
   module Sidekiq
@@ -17,7 +16,6 @@ module RSpec
         # Functional settings defaults
         @clear_all_enqueued_jobs = true
         @warn_when_jobs_not_processed_by_sidekiq = true
-        @silence_warnings = Set.new
       end
 
       def sidekiq_gte_7?
@@ -26,14 +24,6 @@ module RSpec
 
       def sidekiq_gte_8?
         Gem::Version.new(::Sidekiq::VERSION) >= Gem::Version.new("8.0.0")
-      end
-
-      def silence_warning(symbol)
-        @silence_warnings << symbol
-      end
-
-      def warn_for?(symbol)
-        !@silence_warnings.include?(symbol)
       end
     end
   end


### PR DESCRIPTION
This is a configuration to suppress warnings, but I think it's probably no longer necessary after the following commit: https://github.com/wspurgin/rspec-sidekiq/commit/8066f7c0a21a4ed08095d1c7909161bc50734d7b