### PR TITLE
Add `never` matcher for aliasing `exactly(0)`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 Unreleased
 ---
+* Add `never` matcher for aliasing `exactly(0)` (#256)
 
 5.1.0
 ---

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ end
 
 # A specific number of times
 
+expect { AwesomeJob.perform_async }.to enqueue_sidekiq_job.never
+expect { AwesomeJob.perform_async }.to enqueue_sidekiq_job.exactly(0)
+expect { AwesomeJob.perform_async }.to enqueue_sidekiq_job.exactly(0).time
 expect { AwesomeJob.perform_async }.to enqueue_sidekiq_job.once
 expect { AwesomeJob.perform_async }.to enqueue_sidekiq_job.exactly(1).time
 expect { AwesomeJob.perform_async }.to enqueue_sidekiq_job.exactly(:once)

--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -214,6 +214,11 @@ module RSpec
           self
         end
 
+        def never
+          set_expected_count :exactly, 0
+          self
+        end
+
         def once
           set_expected_count :exactly, 1
           self

--- a/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/enqueue_sidekiq_job_spec.rb
@@ -300,6 +300,16 @@ RSpec.describe RSpec::Sidekiq::Matchers::EnqueueSidekiqJob do
     end
 
     context "with expected count" do
+      it "ensure that jobs with no arguments are not invoked" do
+        expect { "does noting" }.to enqueue_sidekiq_job.never
+      end
+
+      it "fails if a job with no arguments is invoked" do
+        expect do
+          expect { worker.perform_async }.to enqueue_sidekiq_job.never
+        end.to raise_error(/expected to enqueue 0 .* job.*but enqueued only jobs/m)
+      end
+
       it "zero" do
         expect {
           "does nothing"


### PR DESCRIPTION
Like a: https://www.rubydoc.info/gems/rspec-mocks/RSpec%2FMocks%2FMessageExpectation:never