### PR TITLE
Fix value comparison in job context matcher

### DIFF
--- a/lib/rspec/sidekiq/matchers/base.rb
+++ b/lib/rspec/sidekiq/matchers/base.rb
@@ -28,7 +28,7 @@ module RSpec
               # send to custom evaluator
               at_evaluator(value)
             else
-              job.context.has_key?(key) && RSpec::Support::FuzzyMatcher.values_match?(value, job.context[key])
+              job.context.has_key?(key) && RSpec::Support::FuzzyMatcher.values_match?(value&.to_s, job.context[key]&.to_s)
             end
           end
         end


### PR DESCRIPTION
The matcher that checks that a job has been enqueued on a specific queue isn't working properly with symbols.

So if I do:

```rb
expect(Sidekiq::Consumer::GiftDeliveryJob).to have_enqueued_sidekiq_job.on(:scheduled_gifts)
```

...It fails, but if I do

```rb
expect(Sidekiq::Consumer::GiftDeliveryJob).to have_enqueued_sidekiq_job.on("scheduled_gifts")
```

... It passes.

Given that the queue in sidekiq can be set both with symbols and strings, the expectation should handle this gracefully.

Before I add tests, I'd like to get thoughts on this. 

Thanks.
