### PR TITLE
Remove require sidekiq/testing deprecation message

### DIFF
--- a/lib/rspec-sidekiq.rb
+++ b/lib/rspec-sidekiq.rb
@@ -3,7 +3,11 @@
 require 'forwardable'
 
 require 'sidekiq'
-require 'sidekiq/testing'
+if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("8.1.1")
+  Sidekiq.testing!(:fake)
+else
+  require "sidekiq/testing"
+end
 
 require_relative 'rspec/sidekiq/batch'
 require_relative 'rspec/sidekiq/configuration'


### PR DESCRIPTION
Hello 👋 

### Summary
- Replace deprecated `require 'sidekiq/testing'` with `Sidekiq.testing!(:fake)` in `rspec-sidekiq.rb`
- The old require-based API is deprecated in Sidekiq 8.1.1 and will be removed in Sidekiq 9.0
- The new explicit `Sidekiq.testing!(:fake)` API is functionally equivalent but makes the intent clearer
- Sidekiq changelog: https://github.com/sidekiq/sidekiq/blob/main/Changes.md#811

**Before**
Running `bundle exec rspec` displayed:
```
`require "sidekiq/testing"` is deprecated and will be removed in Sidekiq 9.0. See https://sidekiq.org/wiki/Testing#new-api
```

**After**
Specs pass, no message displayed.

**To consider**
`s.add_dependency "sidekiq", ">= 5", "< 9"` will be a bit too loose since the new API was added in 8.1.1.