### PR TITLE
Remove implicit ActiveSupport dependency (constantize/try)

### DIFF
--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -77,8 +77,8 @@ if defined? Sidekiq::Batch
               when Class
                 callback.new.send("on_#{event}", self, options)
               when String
-                klass, meth = callback.split('#')
-                klass.constantize.new.send(meth, self, options)
+                klass, meth = callback.split('#', 2)
+                Object.const_get(klass).new.send(meth, self, options)
               else
                 raise ArgumentError, 'Unsupported callback notation'
               end

--- a/lib/rspec/sidekiq/matchers/be_processed_in.rb
+++ b/lib/rspec/sidekiq/matchers/be_processed_in.rb
@@ -25,7 +25,7 @@ module RSpec
           if @klass.methods.include?(:get_sidekiq_options)
             @actual = @klass.get_sidekiq_options['queue']
           else
-            @actual = job.try(:queue_name)
+            @actual = job.respond_to?(:queue_name) ? job.queue_name : nil
           end
           @actual.to_s == @expected_queue.to_s
         end

--- a/spec/rspec/sidekiq/matchers/be_processed_in_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_processed_in_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeProcessedIn do
           expect(string_subject.matches? create_worker queue: 'another_queue').to be false
         end
       end
+
+      context 'when job does not implement queue_name' do
+        it 'returns false without raising error' do
+          expect(string_subject.matches? Object.new).to be false
+        end
+      end
     end
   end
 


### PR DESCRIPTION
rspec-sidekiq was implicitly relying on ActiveSupport-only methods in runtime code:

- constantize in lib/rspec/sidekiq/batch.rb
- try in lib/rspec/sidekiq/matchers/be_processed_in.rb

In environments where Rails/ActiveSupport is not explicitly loaded, this can raise NoMethodError.